### PR TITLE
#11 - Add CI/CD security scanner pipeline

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,2 @@
+paths:
+  - src

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,52 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+     - 'src/**'
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+    paths:
+     - 'src/**'
+  schedule:
+    - cron: '39 6 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [ "main" ]
     paths:
-     - 'src/**'
+     - 'src'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
     paths:
-     - 'src/**'
+     - 'src'
   schedule:
     - cron: '39 6 * * 0'
 
@@ -38,6 +38,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [ "main" ]
     paths:
-     - 'src'
+     - 'src/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
     paths:
-     - 'src'
+     - 'src/**'
   schedule:
     - cron: '39 6 * * 0'
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Follow the official documentation for develop extension with Mozilla.
 .
 ├── LICENSE
 ├── README.md
+├── .github ### Github workflow
+│   ├── codeql
+│   │   └── codeql-config.yml
+│   └── workflows
+│       └── codeql-analysis.yml
 └── src ### Source code of the project.
     ├── content_scripts ### Run particular context
     │   ├── bookmarks.js


### PR DESCRIPTION
Adds Codeql security scanner as a github action. 

Triggers:
- On pushes and pull requests towards `main` if there are any changes in the src folder
- At 06:39 AM, only on Sunday

An example run can be found [here](https://github.com/Jellp/firefox-extension-efficient-tab-manager/actions/runs/3344394614)

Should solve #11 😄 